### PR TITLE
Make sure canonical is always loaded

### DIFF
--- a/public/class-tw-seo-public.php
+++ b/public/class-tw-seo-public.php
@@ -311,7 +311,7 @@ class Tw_Seo_Public {
     
     public function add_wp_missing_canonical_archives() {
 
-        if( is_archive() ) {
+        if( is_archive() || is_home() || is_front_page() ) {
 
             echo '<link rel="canonical" href="'. $this->url .'">';
 


### PR DESCRIPTION
We had canonical on archives but is_home or is_front_page are not archives per se, however also no single posts. So with this change canonical are added everywhere.